### PR TITLE
feat(backend): implement cookie-based JWT authentication with CSRF protection

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
 	java
 	id("org.springframework.boot") version "3.5.5"
 	id("io.spring.dependency-management") version "1.1.7"
+	id("jacoco")
 }
 
 group = "pl.musmike"
@@ -26,6 +27,7 @@ repositories {
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+	implementation("org.springframework.boot:spring-boot-starter-actuator")
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-web")
@@ -50,6 +52,37 @@ dependencyManagement {
     imports {
         mavenBom("org.testcontainers:testcontainers-bom:1.19.7")
     }
+}
+
+jacoco {
+	toolVersion = "0.8.11"
+}
+
+tasks.test {
+	finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+	dependsOn(tasks.test)
+
+	reports {
+		xml.required.set(true)
+		csv.required.set(false)
+		html.required.set(true)
+		html.outputLocation.set(layout.buildDirectory.dir("reports/jacoco/test/html"))
+	}
+
+	classDirectories.setFrom(
+		files(classDirectories.files.map {
+			fileTree(it) {
+				exclude(
+					"**/dto/**",
+					"**/model/**",
+					"**/*Application.class"
+				)
+			}
+		})
+	)
 }
 
 tasks.withType<Test> {

--- a/backend/src/main/java/com/musmike/familyheritage/config/CsrfTokenFilter.java
+++ b/backend/src/main/java/com/musmike/familyheritage/config/CsrfTokenFilter.java
@@ -1,0 +1,65 @@
+// /home/musmike/Documents/projects/github_projects/family-heritage-home-server-app/backend/src/main/java/com/musmike/familyheritage/config/CsrfTokenFilter.java
+package com.musmike.familyheritage.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+@Component
+public class CsrfTokenFilter extends OncePerRequestFilter {
+
+    private static final String XSRF_TOKEN_COOKIE_NAME = "XSRF-TOKEN";
+    private static final String XSRF_TOKEN_HEADER_NAME = "X-XSRF-TOKEN";
+    private static final Set<String> ALLOWED_METHODS = new HashSet<>(
+            Arrays.asList(HttpMethod.GET.name(), HttpMethod.HEAD.name(), HttpMethod.OPTIONS.name(), HttpMethod.TRACE.name())
+    );
+
+    // Lista ścieżek, które mają być ignorowane przez filtr CSRF
+    private final RequestMatcher authEndpointsMatcher = new AntPathRequestMatcher("/auth/**");
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        // Jeśli żądanie pasuje do ścieżek /api/auth/**, pomiń filtr
+        if (authEndpointsMatcher.matches(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (ALLOWED_METHODS.contains(request.getMethod())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String headerToken = request.getHeader(XSRF_TOKEN_HEADER_NAME);
+        String cookieToken = null;
+
+        if (request.getCookies() != null) {
+            cookieToken = Arrays.stream(request.getCookies())
+                    .filter(cookie -> XSRF_TOKEN_COOKIE_NAME.equals(cookie.getName()))
+                    .map(Cookie::getValue)
+                    .findFirst()
+                    .orElse(null);
+        }
+
+        if (headerToken == null || cookieToken == null || !headerToken.equals(cookieToken)) {
+            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Invalid CSRF Token");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/com/musmike/familyheritage/config/DataInitializer.java
+++ b/backend/src/main/java/com/musmike/familyheritage/config/DataInitializer.java
@@ -1,0 +1,118 @@
+package com.musmike.familyheritage.config;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.musmike.familyheritage.dto.UserSeedDto;
+import com.musmike.familyheritage.model.Role;
+import com.musmike.familyheritage.model.User;
+import com.musmike.familyheritage.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class DataInitializer implements CommandLineRunner {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final ObjectMapper objectMapper;
+
+    @Value("${app.seed-users-json:}")
+    private String seedUsersJson;
+
+    @Override
+    public void run(String... args) {
+        if (!StringUtils.hasText(seedUsersJson)) {
+            log.info("SKIP: No seed user data found in configuration.");
+            return;
+        }
+
+        try {
+            List<UserSeedDto> usersToSeed = objectMapper.readValue(seedUsersJson, new TypeReference<>() {});
+            int updatedCount = 0;
+
+            for (UserSeedDto dto : usersToSeed) {
+                if (processUser(dto)) {
+                    updatedCount++;
+                }
+            }
+
+            if (updatedCount > 0) {
+                log.info("DataInitializer: Updated or created {} users.", updatedCount);
+            } else {
+                log.info("DataInitializer: All users are up-to-date. No database changes.");
+            }
+
+        } catch (Exception e) {
+            log.error("CRITICAL: Error parsing seed-users-json: ", e);
+        }
+    }
+
+    /**
+     * @return true if the database was modified, false if skipped
+     */
+    private boolean processUser(UserSeedDto dto) {
+        Optional<User> existingUserOpt = userRepository.findByUsername(dto.getUsername());
+
+        // SCENARIO 1: User does not exist -> Create new
+        if (existingUserOpt.isEmpty()) {
+            createNewUser(dto);
+            return true;
+        }
+
+        // SCENARIO 2: User exists -> Check if update is needed
+        User existingUser = existingUserOpt.get();
+        boolean needsUpdate = false;
+
+        // 1. Check role
+        try {
+            Role vaultRole = Role.valueOf(dto.getRole());
+            if (!existingUser.getRole().equals(vaultRole)) {
+                log.info("Role changed for {}: {} -> {}", dto.getUsername(), existingUser.getRole(), vaultRole);
+                existingUser.setRole(vaultRole);
+                needsUpdate = true;
+            }
+        } catch (IllegalArgumentException e) {
+            log.warn("Invalid role in Vault for user {}: {}", dto.getUsername(), dto.getRole());
+        }
+
+        // 2. Check password
+        if (!passwordEncoder.matches(dto.getPassword(), existingUser.getPassword())) {
+            log.info("Password change detected in Vault for user: {}", dto.getUsername());
+            existingUser.setPassword(passwordEncoder.encode(dto.getPassword()));
+            needsUpdate = true;
+        }
+
+        // Save only if something changed
+        if (needsUpdate) {
+            userRepository.save(existingUser);
+            log.info("Saved changes for user: {}", dto.getUsername());
+            return true;
+        } else {
+            log.debug("No changes for user: {}", dto.getUsername());
+            return false;
+        }
+    }
+
+    private void createNewUser(UserSeedDto dto) {
+        try {
+            User newUser = new User();
+            newUser.setUsername(dto.getUsername());
+            newUser.setPassword(passwordEncoder.encode(dto.getPassword()));
+            newUser.setRole(Role.valueOf(dto.getRole()));
+            userRepository.save(newUser);
+            log.info("Created new user: {}", dto.getUsername());
+        } catch (Exception e) {
+            log.error("Failed to create user {}: {}", dto.getUsername(), e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/com/musmike/familyheritage/config/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/musmike/familyheritage/config/JwtAuthenticationFilter.java
@@ -1,0 +1,76 @@
+package com.musmike.familyheritage.config;
+
+import com.musmike.familyheritage.service.JwtService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final UserDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(JwtService jwtService, UserDetailsService userDetailsService) {
+        this.jwtService = jwtService;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String jwt = extractTokenFromCookies(request);
+
+        if (jwt != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            try {
+                String username = jwtService.extractUsername(jwt);
+
+                if (username != null) {
+                    UserDetails userDetails = this.userDetailsService.loadUserByUsername(username);
+
+                    if (jwtService.isTokenValid(jwt, userDetails)) {
+                        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                                userDetails,
+                                null,
+                                userDetails.getAuthorities()
+                        );
+                        authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                        SecurityContextHolder.getContext().setAuthentication(authToken);
+                    }
+                }
+            } catch (Exception e) {
+                logger.debug("Cannot set user authentication: {}", e);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractTokenFromCookies(HttpServletRequest request) {
+        if (request.getCookies() != null) {
+            return Arrays.stream(request.getCookies())
+                    .filter(cookie -> "access_token".equals(cookie.getName()))
+                    .map(Cookie::getValue)
+                    .findFirst()
+                    .orElse(null);
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/com/musmike/familyheritage/config/SecurityConfig.java
+++ b/backend/src/main/java/com/musmike/familyheritage/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -12,10 +13,26 @@ import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthFilter;
+    private final CsrfTokenFilter csrfTokenFilter;
+    private final CorsProperties corsProperties;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthFilter,
+                          CsrfTokenFilter csrfTokenFilter,
+                          CorsProperties corsProperties) {
+        this.jwtAuthFilter = jwtAuthFilter;
+        this.csrfTokenFilter = csrfTokenFilter;
+        this.corsProperties = corsProperties;
+    }
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
@@ -25,12 +42,30 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/health", "/api/auth/login").permitAll()
-                        .anyRequest().authenticated()
-                )
+                        .requestMatchers("/actuator/**", "/auth/**").permitAll()
+                        .anyRequest().authenticated())
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(csrfTokenFilter, JwtAuthenticationFilter.class)
                 .build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(corsProperties.getAllowedOrigins());
+        configuration.setAllowedMethods(corsProperties.getAllowedMethods());
+        configuration.setAllowedHeaders(java.util.List.of("*"));
+        configuration.setAllowCredentials(corsProperties.isAllowCredentials());
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        // ZMIEŃ TĘ LINIĘ
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 
     @Bean
@@ -44,7 +79,6 @@ public class SecurityConfig {
         DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
         provider.setUserDetailsService(userDetailsService);
         provider.setPasswordEncoder(passwordEncoder);
-
         return provider;
     }
 }

--- a/backend/src/main/java/com/musmike/familyheritage/controller/AuthenticationController.java
+++ b/backend/src/main/java/com/musmike/familyheritage/controller/AuthenticationController.java
@@ -1,37 +1,139 @@
 package com.musmike.familyheritage.controller;
 
+import com.musmike.familyheritage.dto.ErrorResponse;
 import com.musmike.familyheritage.dto.LoginRequest;
-import com.musmike.familyheritage.dto.LoginResponse;
 import com.musmike.familyheritage.service.JwtService;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.LockedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CookieValue;
+
+import java.util.UUID;
 
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/auth")
 public class AuthenticationController {
 
+    private static final Logger logger = LoggerFactory.getLogger(AuthenticationController.class);
     private final JwtService jwtService;
     private final AuthenticationManager authenticationManager;
+    private final UserDetailsService userDetailsService;
 
-    public AuthenticationController(JwtService jwtService, AuthenticationManager authenticationManager) {
+    @Value("${app.jwt.access-expiration-ms}")
+    private long accessExpirationMs;
+
+    @Value("${app.jwt.refresh-expiration-ms}")
+    private long refreshExpirationMs;
+
+    public AuthenticationController(JwtService jwtService,
+                                    AuthenticationManager authenticationManager, UserDetailsService userDetailsService) {
         this.jwtService = jwtService;
         this.authenticationManager = authenticationManager;
+        this.userDetailsService = userDetailsService;
     }
 
     @PostMapping("/login")
-    public LoginResponse login(@RequestBody LoginRequest request) {
-        Authentication authentication = authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword())
-        );
+    public ResponseEntity<?> login(@RequestBody LoginRequest request, HttpServletResponse response) {
+        try {
+            Authentication authentication = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword())
+            );
 
-        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-        String token = jwtService.generateToken(userDetails);
-        return new LoginResponse(token);
+            UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+
+            String accessToken = jwtService.generateAccessToken(userDetails);
+            String refreshToken = jwtService.generateRefreshToken(userDetails);
+            String xsrfToken = UUID.randomUUID().toString();
+
+            ResponseCookie accessTokenCookie = createCookie("access_token", accessToken, accessExpirationMs / 1000, "/", true);
+            ResponseCookie refreshTokenCookie = createCookie("refresh_token", refreshToken, refreshExpirationMs / 1000, "/api/auth", true);
+            ResponseCookie xsrfTokenCookie = createCookie("XSRF-TOKEN", xsrfToken, accessExpirationMs / 1000, "/", false);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.add(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+            headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+            headers.add(HttpHeaders.SET_COOKIE, xsrfTokenCookie.toString());
+
+            return ResponseEntity.ok().headers(headers).build();
+
+        } catch (BadCredentialsException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ErrorResponse("BAD_CREDENTIALS", "Invalid username or password."));
+        } catch (LockedException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(new ErrorResponse("ACCOUNT_LOCKED", "This account has been locked."));
+        } catch (DisabledException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(new ErrorResponse("ACCOUNT_DISABLED", "This account has been disabled."));
+        } catch (AuthenticationException e) {
+            logger.warn("Authentication failed for user {}: {}", request.getUsername(), e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ErrorResponse("AUTHENTICATION_FAILED", "Authentication failed."));
+        } catch (Exception e) {
+            logger.error("An unexpected error occurred during login for user {}", request.getUsername(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ErrorResponse("INTERNAL_SERVER_ERROR", "An unexpected error occurred."));
+        }
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<Void> refreshToken(@CookieValue(name = "refresh_token") String refreshToken, HttpServletResponse response) {
+        try {
+            String username = jwtService.extractUsername(refreshToken);
+            UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+            if (jwtService.isTokenValid(refreshToken, userDetails)) {
+                String newAccessToken = jwtService.generateAccessToken(userDetails);
+                String newXsrfToken = UUID.randomUUID().toString();
+
+                ResponseCookie accessTokenCookie = createCookie("access_token", newAccessToken, accessExpirationMs / 1000, "/", true);
+                ResponseCookie xsrfTokenCookie = createCookie("XSRF-TOKEN", newXsrfToken, accessExpirationMs / 1000, "/", false);
+
+                response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+                response.addHeader(HttpHeaders.SET_COOKIE, xsrfTokenCookie.toString());
+
+                return ResponseEntity.ok().build();
+            }
+        } catch (Exception e) {
+            logger.error("Refresh token error: ", e);
+        }
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletResponse response) {
+        ResponseCookie accessTokenCookie = createCookie("access_token", "", 0, "/", true);
+        ResponseCookie refreshTokenCookie = createCookie("refresh_token", "", 0, "/api/auth", true);
+        ResponseCookie xsrfTokenCookie = createCookie("XSRF-TOKEN", "", 0, "/", false);
+
+        response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, xsrfTokenCookie.toString());
+        return ResponseEntity.ok().build();
+    }
+
+    private ResponseCookie createCookie(String name, String value, long maxAgeInSeconds, String path, boolean httpOnly) {
+        return ResponseCookie.from(name, value)
+                .httpOnly(httpOnly)
+                .secure(false) // Set to true in production with HTTPS
+                .path(path)
+                .maxAge(maxAgeInSeconds)
+                .sameSite("Lax")
+                .build();
     }
 }

--- a/backend/src/main/java/com/musmike/familyheritage/controller/UserController.java
+++ b/backend/src/main/java/com/musmike/familyheritage/controller/UserController.java
@@ -1,0 +1,38 @@
+package com.musmike.familyheritage.controller;
+
+import com.musmike.familyheritage.dto.UserDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    @GetMapping("/me")
+    public ResponseEntity<UserDto> getCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null ||
+                !authentication.isAuthenticated() ||
+                "anonymousUser".equals(authentication.getPrincipal())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        String username = authentication.getName();
+        List<String> roles = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toList());
+
+        UserDto userDto = new UserDto(username, roles);
+        return ResponseEntity.ok(userDto);
+    }
+}

--- a/backend/src/main/java/com/musmike/familyheritage/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/musmike/familyheritage/dto/ErrorResponse.java
@@ -1,0 +1,12 @@
+package com.musmike.familyheritage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ErrorResponse {
+    private String errorCode;
+    private String message;
+}
+

--- a/backend/src/main/java/com/musmike/familyheritage/dto/UserDto.java
+++ b/backend/src/main/java/com/musmike/familyheritage/dto/UserDto.java
@@ -1,0 +1,12 @@
+package com.musmike.familyheritage.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class UserDto {
+    private String username;
+    private List<String> roles;
+}

--- a/backend/src/main/java/com/musmike/familyheritage/dto/UserSeedDto.java
+++ b/backend/src/main/java/com/musmike/familyheritage/dto/UserSeedDto.java
@@ -1,0 +1,10 @@
+package com.musmike.familyheritage.dto;
+
+import lombok.Data;
+
+@Data
+public class UserSeedDto {
+    private String username;
+    private String password;
+    private String role;
+}

--- a/backend/src/main/java/com/musmike/familyheritage/service/JwtService.java
+++ b/backend/src/main/java/com/musmike/familyheritage/service/JwtService.java
@@ -1,17 +1,21 @@
 package com.musmike.familyheritage.service;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
-
 import javax.crypto.SecretKey;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 public class JwtService {
@@ -19,8 +23,11 @@ public class JwtService {
     @Value("${app.jwt.secret}")
     private String jwtSecret;
 
-    @Value("${app.jwt.expiration-ms}")
-    private long jwtExpirationMs;
+    @Value("${app.jwt.access-expiration-ms}")
+    private long accessExpirationMs;
+
+    @Value("${app.jwt.refresh-expiration-ms}")
+    private long refreshExpirationMs;
 
     private SecretKey signingKey;
 
@@ -35,18 +42,51 @@ public class JwtService {
         this.signingKey = Keys.hmacShaKeyFor(keyBytes);
     }
 
-    public String generateToken(UserDetails userDetails) {
-        Map<String, Object> claims = new HashMap<>();
-        return createToken(claims, userDetails.getUsername());
+    public String generateAccessToken(UserDetails userDetails) {
+        return generateToken(new HashMap<>(), userDetails.getUsername(), accessExpirationMs);
     }
 
-    private String createToken(Map<String, Object> claims, String subject) {
+    public String generateRefreshToken(UserDetails userDetails) {
+        return generateToken(new HashMap<>(), userDetails.getUsername(), refreshExpirationMs);
+    }
+
+    private String generateToken(Map<String, Object> claims, String subject, long expiration) {
         return Jwts.builder()
                 .claims(claims)
                 .subject(subject)
                 .issuedAt(new Date(System.currentTimeMillis()))
-                .expiration(new Date(System.currentTimeMillis() + jwtExpirationMs))
+                .expiration(new Date(System.currentTimeMillis() + expiration))
                 .signWith(this.signingKey)
                 .compact();
+    }
+
+    public boolean isTokenValid(String token, UserDetails userDetails) {
+        final String username = extractUsername(token);
+        return (username.equals(userDetails.getUsername())) && !isTokenExpired(token);
+    }
+
+    public String extractUsername(String token) {
+        return extractClaim(token, Claims::getSubject);
+    }
+
+    private boolean isTokenExpired(String token) {
+        return extractExpiration(token).before(new Date());
+    }
+
+    private Date extractExpiration(String token) {
+        return extractClaim(token, Claims::getExpiration);
+    }
+
+    public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
+        final Claims claims = extractAllClaims(token);
+        return claimsResolver.apply(claims);
+    }
+
+    private Claims extractAllClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(signingKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
     }
 }

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -1,10 +1,10 @@
 spring:
   config:
     activate:
-      on-profile: staging
+      on-profile: dev
 app:
   jwt:
     secret: ${APP_JWT_SECRET}
   cors:
     allowed-origins:
-      - "http://staging.192.168.100.144.nip.io"
+      - "http://dev.192.168.100.144.nip.io"

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: jdbc:postgresql://localhost:5432/family_heritage_dev
+    username: user_dev
+    password: dev123
+app:
+  jwt:
+    secret: LocalJWTSecretKeyForDevelopmentOnly1234567890
+  cors:
+    allowed-origins:
+      - "http://localhost:3000"
+server:
+  servlet:
+    context-path: /api

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,11 +1,10 @@
 spring:
-  jpa:
-    hibernate:
-      ddl-auto: validate
+  config:
+    activate:
+      on-profile: prod
 app:
-  cors:
-    allowed-origins:
-      - "http://${STAGING_SERVER_IP}:3001"
-      - "http://localhost:3001"
   jwt:
     secret: ${APP_JWT_SECRET}
+  cors:
+    allowed-origins:
+      - "http://familyheritage.192.168.100.144.nip.io"

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    default: dev
+    default: local
   application:
     name: family-heritage-backend
   jpa:
@@ -10,16 +10,16 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.PostgreSQLDialect
+    flyway:
+      enabled: true
+      locations: classpath:db/migration
+      baseline-on-migrate: true
 
 server:
   address: 0.0.0.0
-  port: 8080
 
 app:
   cors:
-    allowed-origins:
-      - "http://localhost:3000"
     allowed-methods:
       - "GET"
       - "POST"
@@ -28,5 +28,16 @@ app:
       - "OPTIONS"
     allow-credentials: true
   jwt:
-    secret: ThisIsADevJWTSecretKeyWithEnoughLength123ddfdfdfd
-    expiration-ms: 3600000
+    access-expiration-ms: 900000 # 15 minutes
+    refresh-expiration-ms: 604800000 # 7 days
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+
+logging:
+  level:
+    org.springframework.security: DEBUG
+    web: DEBUG

--- a/backend/src/test/java/com/musmike/familyheritage/controller/AuthenticationControllerTest.java
+++ b/backend/src/test/java/com/musmike/familyheritage/controller/AuthenticationControllerTest.java
@@ -12,12 +12,12 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -53,24 +53,64 @@ class AuthenticationControllerTest {
     }
 
     @Test
-    void shouldReturnJwtTokenWhenLoginIsSuccessful() throws Exception {
+    void shouldSetCookiesOnSuccessfulLogin() throws Exception {
         // GIVEN
         LoginRequest loginRequest = new LoginRequest();
         loginRequest.setUsername("user");
         loginRequest.setPassword("password");
 
-        Authentication auth = new UsernamePasswordAuthenticationToken(
-                new User("user", "pass", Collections.emptyList()), null);
+        UserDetails userDetails = User
+                .withUsername("user")
+                .password("pass")
+                .authorities("ADMIN").build();
+        Authentication auth = new UsernamePasswordAuthenticationToken(userDetails,
+                null, userDetails.getAuthorities());
 
         Mockito.when(authenticationManager.authenticate(any())).thenReturn(auth);
-        Mockito.when(jwtService.generateToken(any())).thenReturn("mocked.jwt.token");
+        Mockito.when(jwtService.generateAccessToken(any())).thenReturn("mocked.access.token");
+        Mockito.when(jwtService.generateRefreshToken(any())).thenReturn("mocked.refresh.token");
 
         // WHEN & THEN
-        mockMvc.perform(post("/api/auth/login")
+        mockMvc.perform(post("/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.token").value("mocked.jwt.token"));
+                .andExpect(cookie().exists("access_token"))
+                .andExpect(cookie().httpOnly("access_token", true))
+                .andExpect(cookie().exists("refresh_token"))
+                .andExpect(cookie().httpOnly("refresh_token", true))
+                .andExpect(cookie().exists("XSRF-TOKEN"))
+                .andExpect(cookie().httpOnly("XSRF-TOKEN", false));
     }
+
+    @Test
+    void shouldReturnUnauthorizedWhenLoginFailsWithBadCredentials() throws Exception {
+        // GIVEN
+        LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setUsername("user");
+        loginRequest.setPassword("wrongpassword");
+
+        Mockito.when(authenticationManager.authenticate(any()))
+                .thenThrow(new BadCredentialsException("Bad credentials"));
+
+        // WHEN & THEN
+        mockMvc.perform(post("/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.errorCode").value("BAD_CREDENTIALS"))
+            .andExpect(jsonPath("$.message").value("Invalid username or password."));
+    }
+
+    @Test
+    void shouldLogoutAndClearCookies() throws Exception {
+        // WHEN & THEN
+        mockMvc.perform(post("/auth/logout"))
+                .andExpect(status().isOk())
+                .andExpect(cookie().maxAge("access_token", 0))
+                .andExpect(cookie().maxAge("refresh_token", 0))
+                .andExpect(cookie().maxAge("XSRF-TOKEN", 0));
+    }
+
+
 }

--- a/backend/src/test/java/com/musmike/familyheritage/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/musmike/familyheritage/controller/UserControllerTest.java
@@ -1,0 +1,36 @@
+package com.musmike.familyheritage.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class UserControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithMockUser(username = "testuser", roles = {"ADMIN"})
+    void shouldReturnCurrentUserWhenAuthenticated() throws Exception {
+        // WHEN & THEN
+        mockMvc.perform(get("/users/me"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value("testuser"))
+                .andExpect(jsonPath("$.roles[0]").value("ROLE_ADMIN"));
+    }
+
+    @Test
+    void shouldReturnForbiddenWhenNotAuthenticated() throws Exception {
+        // WHEN & THEN
+        mockMvc.perform(get("/users/me"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/backend/src/test/java/com/musmike/familyheritage/service/JwtServiceTest.java
+++ b/backend/src/test/java/com/musmike/familyheritage/service/JwtServiceTest.java
@@ -21,24 +21,23 @@ class JwtServiceTest {
     private JwtService jwtService;
 
     private final String testSecret = "VGhpcyBpcyBhIHNlY3VyZSB0ZXN0IGtleSBmb3IgSldUIGVuY29kaW5nIGFuZCBtdXN0IGJlIGxvbmc=";
-    private final long testExpiration = 3600000; // 1 hour
+    private final long testAccessExpiration = 3600000; // 1 hour
 
     @BeforeEach
     void setUp() {
         jwtService = new JwtService();
         ReflectionTestUtils.setField(jwtService, "jwtSecret", testSecret);
-        ReflectionTestUtils.setField(jwtService, "jwtExpirationMs", testExpiration);
-
+        ReflectionTestUtils.setField(jwtService, "accessExpirationMs", testAccessExpiration);
         jwtService.init();
     }
 
     @Test
-    void shouldGenerateTokenWithCorrectUsernameAndExpiration() {
+    void shouldGenerateAccessTokenWithCorrectUsernameAndExpiration() {
         // GIVEN
         UserDetails userDetails = new User("testuser", "password", Collections.emptyList());
 
         // WHEN
-        String token = jwtService.generateToken(userDetails);
+        String token = jwtService.generateAccessToken(userDetails);
 
         // THEN
         assertNotNull(token);
@@ -51,7 +50,7 @@ class JwtServiceTest {
 
         assertEquals("testuser", claims.getSubject());
         assertTrue(claims.getExpiration().after(new Date()));
-        assertTrue(claims.getExpiration().getTime() - claims.getIssuedAt().getTime() <= testExpiration);
+        assertTrue(claims.getExpiration().getTime() - claims.getIssuedAt().getTime() <= testAccessExpiration);
     }
 
     private SecretKey getSigningKey() {


### PR DESCRIPTION
- Add JaCoCo code coverage with exclusions for DTOs/models
- Add Spring Boot Actuator for health/info endpoints
- Implement cookie-based auth with access (15min) and refresh (7day) tokens
- Add CsrfTokenFilter with double-submit cookie pattern
- Add DataInitializer for seeding users from JSON config
- Change auth endpoints from /api/auth/* to /auth/*
- Add logout endpoint and /users/me for current user info
- Update tests for cookie-based flow and error handling